### PR TITLE
Render emails as HTML

### DIFF
--- a/Mekmak.Gman/Mekmak.Gman.Jade/BindToWebBrowser.cs
+++ b/Mekmak.Gman/Mekmak.Gman.Jade/BindToWebBrowser.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Controls;
+using System.Windows;
+
+namespace Mekmak.Gman.Jade
+{
+    public static class BindToWebBrowser
+    {
+        public static readonly DependencyProperty HtmlProperty = DependencyProperty.RegisterAttached(
+            "Html",
+            typeof(string),
+            typeof(BindToWebBrowser),
+            new FrameworkPropertyMetadata(OnHtmlChanged));
+
+        [AttachedPropertyBrowsableForType(typeof(WebBrowser))]
+        public static string GetHtml(WebBrowser d)
+        {
+            return (string)d.GetValue(HtmlProperty);
+        }
+
+        public static void SetHtml(WebBrowser d, string value)
+        {
+            d.SetValue(HtmlProperty, value);
+        }
+
+        static void OnHtmlChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            WebBrowser webBrowser = dependencyObject as WebBrowser;
+            webBrowser?.NavigateToString(e.NewValue as string ?? "");
+        }
+    }
+}

--- a/Mekmak.Gman/Mekmak.Gman.Jade/MainWindow.xaml
+++ b/Mekmak.Gman/Mekmak.Gman.Jade/MainWindow.xaml
@@ -69,7 +69,7 @@
                 <WebBrowser LoadCompleted="WebBrowser_LoadCompleted" DataContext="{Binding Path=SelectedEmail}" src:BindToWebBrowser.Html="{Binding Body}" />
                 <!--<TextBox IsReadOnly="True" VerticalContentAlignment="Top"
                          HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" 
-                         DataContext="{Binding Path=SelectedEmail}" Text="{Binding Body}" Visibility="{Binding ShowText}" />-->
+                         DataContext="{Binding Path=SelectedEmail}" Text="{Binding Body}" />-->
             </Grid>
 
             <Image KeyboardNavigation.TabNavigation="None" Grid.Column="1" Grid.Row="0" MouseRightButtonUp="EmailImage_OnMouseRightButtonUp" DataContext="{Binding Path=SelectedEmail}" Source="{Binding Uri}" RenderTransformOrigin=".5,.5">
@@ -78,7 +78,7 @@
                 </Image.RenderTransform>
             </Image>          
 
-            <StackPanel Grid.Column="0" Grid.ColumnSpan="1" Grid.Row="1" Orientation="Horizontal">
+            <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Orientation="Horizontal">
                 <StackPanel Orientation="Horizontal">
                     <Label Content="Category: "/>
                     <TextBox DataContext="{Binding Path=SelectedEmail}" Text="{Binding Category}" MinWidth="100" TabIndex="0"/>

--- a/Mekmak.Gman/Mekmak.Gman.Jade/MainWindow.xaml
+++ b/Mekmak.Gman/Mekmak.Gman.Jade/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:src="clr-namespace:Mekmak.Gman.Jade"
         mc:Ignorable="d"
         DataContext="local:MainViewModel"
         Title="MainWindow" Height="450" Width="800">
@@ -28,8 +29,8 @@
     </Window.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*"/>
-            <ColumnDefinition Width="4*"/>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="2*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -61,23 +62,23 @@
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <Grid Grid.Column="0" Grid.Row="0" KeyboardNavigation.TabNavigation="None">
-                <TextBox IsReadOnly="True" VerticalContentAlignment="Top"
+                <WebBrowser LoadCompleted="WebBrowser_LoadCompleted" DataContext="{Binding Path=SelectedEmail}" src:BindToWebBrowser.Html="{Binding Body}" />
+                <!--<TextBox IsReadOnly="True" VerticalContentAlignment="Top"
                          HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" 
-                         DataContext="{Binding Path=SelectedEmail}" Text="{Binding Body}"/>
+                         DataContext="{Binding Path=SelectedEmail}" Text="{Binding Body}" Visibility="{Binding ShowText}" />-->
             </Grid>
-            
 
             <Image KeyboardNavigation.TabNavigation="None" Grid.Column="1" Grid.Row="0" MouseRightButtonUp="EmailImage_OnMouseRightButtonUp" DataContext="{Binding Path=SelectedEmail}" Source="{Binding Uri}" RenderTransformOrigin=".5,.5">
                 <Image.RenderTransform>
                     <RotateTransform Angle="{Binding ImageRotateAngle}" />
                 </Image.RenderTransform>
-            </Image>
+            </Image>          
 
-            <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Orientation="Horizontal">
+            <StackPanel Grid.Column="0" Grid.ColumnSpan="1" Grid.Row="1" Orientation="Horizontal">
                 <StackPanel Orientation="Horizontal">
                     <Label Content="Category: "/>
                     <TextBox DataContext="{Binding Path=SelectedEmail}" Text="{Binding Category}" MinWidth="100" TabIndex="0"/>

--- a/Mekmak.Gman/Mekmak.Gman.Jade/MainWindow.xaml.cs
+++ b/Mekmak.Gman/Mekmak.Gman.Jade/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -32,6 +33,22 @@ namespace Mekmak.Gman.Jade
         private void EmailImage_OnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
         {
             ViewModel.RotateImageCommand.Execute(null);
+        }
+
+        private void WebBrowser_LoadCompleted(object sender, NavigationEventArgs e)
+        {
+            // All this to disable the script error windows..
+            var webBrowser = sender as WebBrowser;
+            if (webBrowser == null)
+                return;
+
+	        var objComWebBrowser = typeof(WebBrowser).GetField("_axIWebBrowser2", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(webBrowser);
+	        if (objComWebBrowser == null)
+	        {
+		        return;
+	        }
+
+	        objComWebBrowser.GetType().InvokeMember("Silent", BindingFlags.SetProperty, null, objComWebBrowser, new object[] { true });
         }
     }
 }

--- a/Mekmak.Gman/Mekmak.Gman.Jade/Models/EmailModel.cs
+++ b/Mekmak.Gman/Mekmak.Gman.Jade/Models/EmailModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Windows;
 using Mekmak.Gman.Ore;
 
 namespace Mekmak.Gman.Jade.Models

--- a/Mekmak.Gman/Mekmak.Gman.Jade/Models/EmailModel.cs
+++ b/Mekmak.Gman/Mekmak.Gman.Jade/Models/EmailModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows;
 using Mekmak.Gman.Ore;
 
 namespace Mekmak.Gman.Jade.Models


### PR DESCRIPTION
- Render email contents as html using the `WebBrowser`, which required some magic to be able to bind to HTML, as well as silencing 'script errors' from rendering
- Infer MTA charges, since they are common
- Fix export bug